### PR TITLE
Update `dry-rb` link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ end
 
 ## Alternatives
 
-* [dry-cli](https://dry-rb.org/gems/dry-cli/0.6/)
+* [dry-cli](https://dry-rb.org/gems/dry-cli)
 * [cmdparse](https://cmdparse.gettalong.org/)
 
 ## Special Thanks


### PR DESCRIPTION
`https://dry-rb.org/gems/dry-cli` should always (I hope) link to the newest version 